### PR TITLE
Stricter jsx related rules

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -58,17 +58,17 @@ rules:
   quotes: [2, "single"]
   react/display-name: 2
   react/jsx-boolean-value: [2, "never"]
-  react/jsx-closing-bracket-location: [2, "line-aligned"],
-  react/jsx-curly-spacing: [2, "never", {allowMultiline: false}],
-  react/jsx-equals-spacing: [2, "never"],
-  react/jsx-first-prop-new-line: [2, "multiline"],
-  react/jsx-indent-props: [2, 4],
+  react/jsx-closing-bracket-location: [2, "line-aligned"]
+  react/jsx-curly-spacing: [2, "never", {allowMultiline: false}]
+  react/jsx-equals-spacing: [2, "never"]
+  react/jsx-first-prop-new-line: [2, "multiline"]
+  react/jsx-indent-props: [2, 4]
   react/jsx-indent: [2, 4]
-  react/jsx-key: 2,
-  react/jsx-no-duplicate-props: 2,
+  react/jsx-key: 2
+  react/jsx-no-duplicate-props: 2
   react/jsx-no-undef: 2
   react/jsx-pascal-case: 2
-  react/jsx-space-before-closing: [2, "always"],
+  react/jsx-space-before-closing: [2, "always"]
   react/jsx-uses-react: 2
   react/jsx-uses-vars: 2
   react/no-comment-textnodes: 2

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -58,11 +58,20 @@ rules:
   quotes: [2, "single"]
   react/display-name: 2
   react/jsx-boolean-value: [2, "never"]
+  react/jsx-closing-bracket-location: [2, "line-aligned"],
+  react/jsx-curly-spacing: [2, "never", {allowMultiline: false}],
+  react/jsx-equals-spacing: [2, "never"],
+  react/jsx-first-prop-new-line: [2, "multiline"],
+  react/jsx-indent-props: [2, 4],
   react/jsx-indent: [2, 4]
+  react/jsx-key: 2,
+  react/jsx-no-duplicate-props: 2,
   react/jsx-no-undef: 2
   react/jsx-pascal-case: 2
+  react/jsx-space-before-closing: [2, "always"],
   react/jsx-uses-react: 2
   react/jsx-uses-vars: 2
+  react/no-comment-textnodes: 2
   react/react-in-jsx-scope: 2
   react/self-closing-comp: 2
   react/wrap-multilines: 2


### PR DESCRIPTION
### Added rules:
1. [jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
2. [jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)
3. [jsx-equals-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md)
4. [jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)
5. [jsx-indent-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md)
6. [jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)
7. [jsx-no-comment-textnodes](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md)
8. [jsx-no-duplicate-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md)
9. [jsx-space-before-closing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md)
### Example of correct jsx:

``` js
<section className="example block">
    {/* Comment here */}
    <ComponentWithManyProps
        prop1={1}
        prop2={2}
        prop3={Math.random()}
        prop4="example"
    />

    <span className="rating">
        {[1, 2, 3, 4, 5].map(rating =>
            <i key={rating} className={`star-${rating}`} />
        )}
    </span>
</section>
```
