### PR TITLE
Add no-console rule

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -37,7 +37,7 @@ rules:
   new-cap: [2, {newIsCap: true, capIsNew: false}]
   no-bitwise: 2
   no-class-assign: 2
-  no-console: 0
+  no-console: [2, {allow: ["warn", "error"]}]
   no-const-assign: 2
   no-else-return: 2
   no-eq-null: 2


### PR DESCRIPTION
Quite often `console.log` statements are pushed to the repository by mistake or negligence.

At the same time `console.error` are sometimes used in production code to catch and print errors (when there is no better way to handle errors, not a good practice overall).

This changes will prevent from commiting `console.log`s by mistake, but still allow `console.error` and `console.warn`.

If you really need to use `console.log` you can always add comment to describe that its done on purpose.

ESLint docs: http://eslint.org/docs/rules/no-console

Example of incorrect code:

``` javascript
console.log('Data User Password Authentication');
```

Example of correct code:

``` javascript
try {
} catch(err) {
  console.error(err);
}

console.warn('This method will be deprecated soon');

// eslint-disable-next-line no-console
console.log('Data User Password Authentication');

console.log('Data User Password Authentication');  // eslint-disable-line no-console
```
