### PR TITLE
pass console.info

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -37,7 +37,7 @@ rules:
   new-cap: [2, {newIsCap: true, capIsNew: false}]
   no-bitwise: 2
   no-class-assign: 2
-  no-console: [2, {allow: ["warn", "error"]}]
+  no-console: [2, {allow: ["warn", "error", "info"]}]
   no-const-assign: 2
   no-else-return: 2
   no-eq-null: 2


### PR DESCRIPTION
Sometime you want to show something in console, which isn't kind of error or warn. 

E.g. Path to temp dir (on mac can be different any time)
