### PR TITLE
Add: no-unneeded-ternary

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -51,6 +51,7 @@ rules:
   no-self-compare: 2
   no-trailing-spaces: 2
   no-underscore-dangle: 0
+  no-unneeded-ternary: 2
   no-unused-expressions: 0
   no-use-before-define: 0
   no-useless-call: 2


### PR DESCRIPTION
### Kind

Add rule
### Rule

[no-unneeded-ternary](http://eslint.org/docs/rules/no-unneeded-ternary)
### Why?

Less code = better code.
