### PR TITLE
using local eslint for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ rules:
 {
     "eslintConfig": {
         "extends": "vazco"
+    },
+    
+    "scripts": {
+        "eslint": "$(npm bin)/eslint --ext .js,.jsx ."
     }
 }
 ```


### PR DESCRIPTION
### Kind
Teaching a good practice

### Why?
Currently in many of projects, we are using global installation of eslint.
This makes a lot of problems with wrong version. 

I think we should avoid global dependencies everywhere where we can, even in readme we should give a good practise.

