### PR TITLE
comma-dangle: error, never

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -25,6 +25,7 @@ rules:
   brace-style: [2, "1tbs"]
   camelcase: [1, {properties: "never"}]
   comma-style: [2, "last"]
+  comma-dangle: [2, "never"]
   complexity: [1, 12]
   computed-property-spacing: [2, "never"]
   consistent-return: 1

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -24,8 +24,8 @@ rules:
   arrow-spacing: [2, {before: true, after: true}]
   brace-style: [2, "1tbs"]
   camelcase: [1, {properties: "never"}]
-  comma-style: [2, "last"]
   comma-dangle: [2, "never"]
+  comma-style: [2, "last"]
   complexity: [1, 12]
   computed-property-spacing: [2, "never"]
   consistent-return: 1


### PR DESCRIPTION
### Kind
Add rule:
```
comma-dangle: [2, "never"]
```

### Rule
[comma-dangle](http://eslint.org/docs/rules/comma-dangle)

### Why?
Example of incorrect code:
```
var foo = {
    bar: "baz",
    qux: "quux",
};
```

Example of correct code:
```
var foo = {
    bar: "baz",
    qux: "quux"
};
```