### PR TITLE
space-infix-ops: error

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -86,6 +86,7 @@ rules:
   space-before-blocks: [2, "always"]
   space-before-function-paren: [2, "always"]
   space-in-parens: [2, "never"]
+  space-infix-ops: 2
   strict: [0, "global"]
   valid-jsdoc: 1
   wrap-iife: [2, "any"]


### PR DESCRIPTION
### Kind
Add rule:
```
space-infix-ops: 2
```

### Rule
[space-infix-ops](http://eslint.org/docs/rules/space-infix-ops)

### Why?
The proponents of these extra spaces believe it make the code easier to read and can more easily highlight potential errors.

Example of incorrect code:
```
i+++2
a?b:c
a +b
```

Example of correct code:
```
i++ + 2
a ? b : c
a + b
```
