### PR TITLE
space-unary-ops: {words: true, nonwords: false}

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -86,6 +86,7 @@ rules:
   space-before-blocks: [2, "always"]
   space-before-function-paren: [2, "always"]
   space-in-parens: [2, "never"]
+  space-unary-ops: [2, {"words": true, "nonwords": false}]
   strict: [0, "global"]
   valid-jsdoc: 1
   wrap-iife: [2, "any"]


### PR DESCRIPTION
### Kind
Add rule:
```
space-unary-ops: [2, {"words": true, "nonwords": false}]
```

### Rule
[space-unary-ops](http://eslint.org/docs/rules/space-unary-ops)

### Why?
This is mainly a stylistic issue

Example of incorrect code:
```
if (! foo)
typeof!foo;
typeof! foo;
++ foo
```

Example of correct code:
```
if (!foo)
typeof !foo;
++foo
```