### PR TITLE
Add rule call-parens-newline

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -4,6 +4,7 @@ extends: "eslint:recommended"
 
 plugins:
   - "babel"
+  - "brackets"
   - "react"
   - "vazco"
 
@@ -23,6 +24,7 @@ rules:
   arrow-parens: [2, "as-needed"]
   arrow-spacing: [2, {before: true, after: true}]
   brace-style: [2, "1tbs"]
+  brackets/call-parens-newline: 2
   camelcase: [1, {properties: "never"}]
   comma-dangle: [2, "never"]
   comma-style: [2, "last"]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": "^3.16.1",
     "eslint-plugin-babel": "^4.0.1",
+    "eslint-plugin-brackets": "^0.0.1",
     "eslint-plugin-react": "^6.10.0",
     "eslint-plugin-vazco": "^1.0.0"
   },
@@ -13,6 +14,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": "^3.16.1",
     "eslint-plugin-babel": "^4.0.1",
+    "eslint-plugin-brackets": "^0.0.1",
     "eslint-plugin-react": "^6.10.0",
     "eslint-plugin-vazco": "^1.0.0",
     "yamljs": "^0.2.8"


### PR DESCRIPTION
### Kind
Add rule:
```
brackets/call-parens-newline: 2
```

### Rule
You can also check valid and invalid [tests](https://github.com/kentor/eslint-plugin-brackets/tree/master/lib/rules/__tests__).

### Why?
This is mainly a stylistic issue

Example of **incorrect** code:
```js
call(
  'a',
  'b');
call('a',
  'b');
call('a',
  'b'
);
```

Example of **correct** code:
```js
call(
  'a',
  'b'
);
call(
  'a', {
    b: 'c'
  }
);
call('a', 'b');
```