### PR TITLE
Changed indent to 2 spaces.

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -32,11 +32,11 @@ rules:
   eol-last: 2
   func-names: 1
   guard-for-in: 2
-  indent: [2, 4, {SwitchCase: 1}]
+  indent: [2, 2, {SwitchCase: 1}]
   jsx-quotes: [2, "prefer-double"]
   keyword-spacing: [2, {"after": true, "before": true}]
   linebreak-style: [2, "unix"]
-  max-len: [2, 120, 4]
+  max-len: [2, 120, 2]
   new-cap: [2, {newIsCap: true, capIsNew: false}]
   no-bitwise: 2
   no-class-assign: 2

--- a/configs/prettier.yaml
+++ b/configs/prettier.yaml
@@ -12,4 +12,4 @@ rules:
     - bracketSpacing: false
       printWidth: 120
       singleQuote: true
-      tabWidth: 4
+      tabWidth: 2


### PR DESCRIPTION
Summary | Change indentation to 2 spaces
:-----: | :-----:
Rule name: | `indent`, `max-len` and `prettier/prettier`
Kind: | Change rule
Fixable? | Yes
Link to docs: | [`indent`](http://eslint.org/docs/rules/indent), [`max-len`](http://eslint.org/docs/rules/max-len) and [`prettier/prettier`](https://prettier.io/docs/en/options.html#tab-width)

### Why?
Less visual fuss.
100% visual pleasure-driven proposal.

### Examples of BAD code for this rule:

```javascript
export default class SimpleSchemaBridge extends Bridge {
    // ...
    getErrorMessages (error) {
        if (error) {
            if (Array.isArray(error.details)) {
                return error.details.map(error =>
                    this.schema.messageForError(
                        error.type,
                        error.name,
                        null,
                        error.details &&
                        error.details.value
                    )
                );
            }

            if (error.message) {
                return [error.message];
            }
        }
        // ...
    }
    // ...
}
```

### Examples of GOOD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript
export default class SimpleSchemaBridge extends Bridge {
  // ...
  getErrorMessages (error) {
    if (error) {
      if (Array.isArray(error.details)) {
        return error.details.map(error =>
          this.schema.messageForError(
            error.type,
            error.name,
            null,
            error.details &&
            error.details.value
          )
        );
      }

      if (error.message) {
        return [error.message];
      }
    }
    // ...
  }
  // ...
}
```

---
Requesting feedback from: @vazco/developers