### PR TITLE
Change prettier's print width to 80

### DIFF
--- a/configs/prettier.yaml
+++ b/configs/prettier.yaml
@@ -10,6 +10,6 @@ rules:
   prettier/prettier:
     - error
     - bracketSpacing: false
-      printWidth: 120
+      printWidth: 80
       singleQuote: true
       tabWidth: 2


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | `prettier/prettier: printWidth`
Kind: | Change
Fixable? | Yes
Link to docs: | https://prettier.io/docs/en/options.html#print-width

### Why?
<!-- Please wrote some short explanation -->
From [Prettier's docs](https://prettier.io/docs/en/options.html#print-width):

> For readability we recommend against using more than 80 characters:
> 
> In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don't strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.
> 
> Prettier, on the other hand, strives to fit the most code into every line. With the print width set to 120, prettier may produce overly compact, or otherwise undesirable code.

See the [print width rationale](https://prettier.io/docs/en/rationale.html#print-width) for more information and examples of usage.

<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
