### PR TITLE
Enable trailing commas

### DIFF
--- a/configs/prettier.yaml
+++ b/configs/prettier.yaml
@@ -13,3 +13,4 @@ rules:
       printWidth: 120
       singleQuote: true
       tabWidth: 2
+      trailingComma: all


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | `prettier/prettier: trailingComma`
Kind: | Add rule
Fixable? | Yes
Link to docs: | https://prettier.io/docs/en/options.html#trailing-commas

### Why?
<!-- Please wrote some short explanation -->
Print trailing commas wherever possible when multi-line.
**A single-line array, for example, never gets trailing commas!**

### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript
const a = [
  1,
  2,
  3
];

const c = {
  bar: 'baz',
  qux: 'quux'
};
```

### Examples of GOOD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript
const a = [
  1,
  2,
  3,
];

const b = [1, 2, 3];

const c = {
  bar: 'baz',
  qux: 'quux',
};

const d = {bar: 'baz', qux: 'quux'};
```


<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
