### PR TITLE
Added no-this-in-sfc rule

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -82,6 +82,7 @@ rules:
   react/jsx-uses-react: 2
   react/jsx-uses-vars: 2
   react/jsx-wrap-multilines: [2, {arrow: false}]
+  react/no-this-in-sfc: 2
   react/react-in-jsx-scope: 2
   react/self-closing-comp: 2
   semi: [2, "always"]


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | react/no-this-in-sfc
Kind: | Add rule
Fixable? | No
Link to docs: | https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/no-this-in-sfc.md

### Why?
<!-- Please wrote some short explanation -->
Prevents a common mistake when transforming class component into SFC.

### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

function Foo(props) {
  const { loading } = this.state;
  const { bar } = this.props;
  if (loading) {
    return <Loader />;
  }
  return (
    <div>
      {bar}
    </div>
  );
}

```

### Examples of GOOD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

function Foo(props, context) {
  const { foo } = context;
  const { bar } = props;
  return (
    <div>
      {foo ? bar : ''}
    </div>
  );
}

```


<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
