### PR TITLE
Updated Prettier to 2.0.

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -53,10 +53,12 @@ rules:
   prefer-spread: 1
   prettier/prettier:
     - error
-    - bracketSpacing: true
+    - arrowParens: avoid
+      bracketSpacing: true
       printWidth: 80
       singleQuote: true
       tabWidth: 2
+      trailingComma: none
   react/display-name: 2
   react/jsx-boolean-value: [2, "never"]
   react/jsx-key: 2

--- a/configs/typescript.yaml
+++ b/configs/typescript.yaml
@@ -35,7 +35,8 @@ settings:
 rules:
   prettier/prettier:
     - error
-    - bracketSpacing: true
+    - arrowParens: avoid
+      bracketSpacing: true
       printWidth: 80
       singleQuote: true
       tabWidth: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,9 +1304,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-vazco": "1.0.0",
     "npm-run-all": "4.1.5",
-    "prettier": "1.18.2",
+    "prettier": "2.0.2",
     "typescript": "3.6.4",
     "yamljs": "0.3.0"
   },
@@ -29,7 +29,7 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-vazco": "^1.0.0",
     "typescript": "^3.6.4",
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.2"
   },
   "main": "default.json",
   "files": [


### PR DESCRIPTION
Read more about Prettier 2 [in the official announcement](https://prettier.io/blog/2020/03/21/2.0.0.html). I've covered all style-related braking changes in the config, but the **minimum Node version is now 10**.