### PR TITLE
Switched curly to multi.

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -26,6 +26,7 @@ rules:
   camelcase: [1, {properties: "never"}]
   complexity: [1, 12]
   consistent-return: 1
+  curly: ["error", "multi"]
   eqeqeq: 2
   func-names: 1
   guard-for-in: 2


### PR DESCRIPTION
Summary | |
:-----: | :-----:
Rule name: | `curly`
Kind: | Change
Fixable? | Yes
Link to docs: | [https://eslint.org/docs/rules/curly](https://eslint.org/docs/rules/curly)

### Why?

Right now there's no enforced style of braces. I've checked out how most of our projects look like and based this change on that. In short, braces are present if and only if the block is larger than one line.

### Examples of BAD code for this rule:

```javascript
if (foo) {
    foo++;
}

if (foo) bar();
else {
    foo++;
}

while (true) {
    doSomething();
}

for (var i=0; i < items.length; i++) {
    doSomething();
}
```

### Examples of GOOD code for this rule:

```javascript
if (foo) foo++;
else foo();

while (true) {
    doSomething();
    doSomethingElse();
}
```

---
Requesting feedback from: @vazco/developers
