### PR TITLE
Switched curly to all.

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -26,6 +26,7 @@ rules:
   camelcase: [1, {properties: "never"}]
   complexity: [1, 12]
   consistent-return: 1
+  curly: ["error", "all"]
   eqeqeq: 2
   func-names: 1
   guard-for-in: 2


### PR DESCRIPTION
Summary | |
:-----: | :-----:
Rule name: | `curly`
Kind: | Change
Fixable? | Yes
Link to docs: | [https://eslint.org/docs/rules/curly](https://eslint.org/docs/rules/curly)

### Why?

Right now there's no enforced style of braces. I thought that `multi` will be OK, but #61 showed that it's not.

### Examples of BAD code for this rule:

```javascript
if (foo) foo++;

while (bar)
    baz();

if (foo) {
    baz();
} else qux();
```

### Examples of GOOD code for this rule:

```javascript
if (foo) {
    foo++;
}

while (bar) {
    baz();
}

if (foo) {
    baz();
} else {
    qux();
}
```

---
Requesting feedback from: @vazco/developers
