### PR TITLE
Changed default config trailingComma rule to all.

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -75,7 +75,7 @@ rules:
       printWidth: 80
       singleQuote: true
       tabWidth: 2
-      trailingComma: none
+      trailingComma: all
   react/display-name: 2
   react/jsx-boolean-value: [2, "never"]
   react/jsx-key: 2


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | prettier: trailingComma: all
Kind: | Change
Fixable? | Yes
Link to docs: | https://prettier.io/docs/en/options.html#trailing-commas

### Why?
<!-- Please wrote some short explanation -->
When working in complex components and functions using GIT we can encounter undesired behavior. Imagine we have list:
```js
[
  'Pseudopseudohypoparathyroidism',
  'Floccinaucinihilipilification',
  'Antidisestablishmentarianism'
]
```

And we want to add another element, diff shows:
```diff
[
  'Pseudopseudohypoparathyroidism',
  'Floccinaucinihilipilification',
- 'Antidisestablishmentarianism' 
+ 'Antidisestablishmentarianism',    // add comma
+ 'Honorificabilitudinitatibus'    // add another element
]
```
So we added two lines adding one item.
There are some ways to avoid this, e.g in Elm (inherited from Haskell):
```diff
[
  'Pseudopseudohypoparathyroidism'
  , 'Floccinaucinihilipilification'
  , 'Antidisestablishmentarianism'
+ , 'Honorificabilitudinitatibus'    // add another element
]
```
But I don't really like it, I thing so do you. 

**A `trailingComma: all` comes with help**, it enforces us to add comma even if there is no more elements in list (or function arguments). 
Our example with `trailingComma: all` looks like this:
```diff
[
  'Pseudopseudohypoparathyroidism',
  'Floccinaucinihilipilification',
  'Antidisestablishmentarianism', 
+ 'Honorificabilitudinitatibus',    // add another element
]
```
Trailing commas runs well in node 8 and above.

This rule was originally implemented in TS eslint config, but in #64 we decided to unify it with default config. Now I want to ask if we want change base config rule to `all`.

**Bonus**: Don't worry about single line lists, they stay as they were.

### Examples of BAD code for this rule:
```js
[
  'Pseudopseudohypoparathyroidism',
  'Floccinaucinihilipilification',
  'Antidisestablishmentarianism', 
  'Honorificabilitudinitatibus'
]  
```
```js
['a', 'b', 'c',]  
```

### Examples of GOOD code for this rule:
```js
[
  'Pseudopseudohypoparathyroidism',
  'Floccinaucinihilipilification',
  'Antidisestablishmentarianism', 
  'Honorificabilitudinitatibus',
]  
```
```js
['a', 'b', 'c']  
```

<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
