### PR TITLE
Add eslint-plugin-react-hooks

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -9,6 +9,7 @@ plugins:
   - import
   - prettier
   - react
+  - react-hooks
   - vazco
 
 env:
@@ -76,6 +77,8 @@ rules:
       singleQuote: true
       tabWidth: 2
       trailingComma: none
+  react-hooks/rules-of-hooks: 2
+  react-hooks/exhaustive-deps: 2
   react/display-name: 2
   react/jsx-boolean-value: [2, "never"]
   react/jsx-key: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,6 +755,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.0.tgz",
+      "integrity": "sha512-YKBY+kilK5wrwIdQnCF395Ya6nDro3EAMoe+2xFkmyklyhF16fH83TrQOo9zbZIDxBsXFgBbywta/0JKRNFDkw==",
+      "dev": true
+    },
     "eslint-plugin-vazco": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vazco/-/eslint-plugin-vazco-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint-plugin-import": "2.20.2",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.16.0",
+    "eslint-plugin-react-hooks": "4.0.0",
     "eslint-plugin-vazco": "1.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.0.2",
@@ -29,6 +30,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-react-hooks": "^4.0.0",
     "eslint-plugin-vazco": "^1.0.0",
     "typescript": "^3.6.4",
     "prettier": "^2.0.2"


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | `react-hooks/rules-of-hooks` `react-hooks/exhaustive-deps`
Kind: | Add
Fixable? | Yes
Link to docs: | https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks 

### Why?
<!-- Please wrote some short explanation -->
This plugin enforces correct usage of React hooks as specified by rules of hooks: https://reactjs.org/docs/hooks-rules.html

It enforces good hooks practices, consistency and most importantly helps avoid bugs with wrong usage of hooks (also makes reviews faster/easier since there are less things to check).


### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->
Example taken from: https://reactjs.org/docs/hooks-rules.html
```javascript
  if (name !== '') {
    useEffect(function persistForm() {
      localStorage.setItem('formData', name);
    });
  }
```

### Examples of GOOD code for this rule:
Example taken from: https://reactjs.org/docs/hooks-rules.html
```javascript
  useEffect(function persistForm() {
    // 👍 We're not breaking the first rule anymore
    if (name !== '') {
      localStorage.setItem('formData', name);
    }
  });
```

### Points for discussion
The `react-hooks/exhaustive-deps` in recommended `react-hooks` config is set as warn. From my experience, warnings get ignored too often especially in bigger codebases and this rule is too important to set it as warn. In my opinion it is better to set this rule to error and explicitly ignore it where needed with an explanation about why it was ignored.

Another thing to keep in mind is that running the `--fix` flag automatically adds any missing dependencies that were detected by this rule. This behaviour can create bugs/change behaviour of code that was seemingly working fine before, so it is important to check what this rule added and where. In my opinion this is not a bad behaviour because most of the time missing a dependency was a developer's oversight and can lead to serious bugs.

<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
