### PR TITLE
Remove vazco/no-console

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -10,7 +10,6 @@ plugins:
   - prettier
   - react
   - react-hooks
-  - vazco
 
 env:
   browser: true
@@ -95,7 +94,6 @@ rules:
   react/sort-comp: 2
   strict: [0, "global"]
   valid-jsdoc: 1
-  vazco/no-console: [1, {disallow: ["info", "time", "timeEnd"]}]
   yoda: [1, "never"]
 
 settings:

--- a/package-lock.json
+++ b/package-lock.json
@@ -761,12 +761,6 @@
       "integrity": "sha512-YKBY+kilK5wrwIdQnCF395Ya6nDro3EAMoe+2xFkmyklyhF16fH83TrQOo9zbZIDxBsXFgBbywta/0JKRNFDkw==",
       "dev": true
     },
-    "eslint-plugin-vazco": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vazco/-/eslint-plugin-vazco-1.0.0.tgz",
-      "integrity": "sha1-2PJvnVZdlNdKTkQKmk9yu5aT//M=",
-      "dev": true
-    },
     "eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "4.0.0",
-    "eslint-plugin-vazco": "1.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.0.2",
     "typescript": "3.6.4",


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | vazco/no-console
Kind: | Remove
Fixable? | Yes
Link to docs: | https://github.com/vazco/eslint-plugin-vazco

### Why?
<!-- Please wrote some short explanation -->

There are 2 rules which are a bit confusing

```
no-console: [2, {allow: ["warn", "error", "info", "time", "timeEnd"]}]
```

and 

```
vazco/no-console: [1, {disallow: ["info", "time", "timeEnd"]}]
```

So in result `info`, `time`, `timeEnd` are warnings, `warn` and `error` are allowed and the rest is error.
Maybe this is the purpose of `vazco/no-console`, to enable setting different levels of validation for different console methods?
If so, this PR is irrelevant.

This change allows the use of `warn`, `error`, `info`, `time`, `timeEnd` (can be discussed) and the rest is error.


### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

console.log('log')
console.trace()
```

### Examples of GOOD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

console.warn('warning')
console.error('error')
console.info('info')
console.time()
console.timeEnd()
```


<!-- Leave this as it is, this will call eveyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
