### PR TITLE
Disable jsx a11y onchange

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -48,6 +48,7 @@ rules:
       newlines-between: always
       alphabetize:
         order: asc
+  jsx-a11y/no-onchange: 0
   new-cap: [2, {newIsCap: true, capIsNew: false}]
   no-bitwise: 2
   no-class-assign: 2

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "build": "yaml2json -s configs && mv -v configs/*.json .",
     "prepublishOnly": "npm test && npm run build",
     "test": "run-s -nc build test:**",
-    "test:default:tests": "eslint tests --no-eslintrc -c default.json",
-    "test:typescript:tests": "eslint tests --no-eslintrc -c typescript.json",
-    "test:prettier": "eslint-config-prettier tests/empty.js"
+    "test:default:tests": "eslint tests/sampleCode.jsx --no-eslintrc -c default.json",
+    "test:typescript:tests": "eslint tests/sampleCode.jsx --no-eslintrc -c typescript.json",
+    "test:prettier": "eslint-config-prettier tests/sampleCode.jsx"
   },
   "keywords": [
     "eslint",

--- a/tests/sampleCode.jsx
+++ b/tests/sampleCode.jsx
@@ -1,2 +1,4 @@
-// Empty .js file
 // It should be linted correctly unless there are some errors in eslint config rules
+import React from 'react';
+
+<select onChange={undefined} />;


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THIS COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | [jsx-a11y/no-onchange](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md)
Kind: | Change
Fixable? | No
Link to docs: | [jsx-a11y/no-onchange](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md)

### Why?
<!-- Please wrote some short explanation -->
Due to the `onChange` behavior being fixed in most browsers and now only persisting in very old versions of IE this rule has been deprecated. It was already removed from the default plugin configuration but the new plugin version hasn't been released yet. We could opt for waiting for the new plugin version but we do not know when it will be released (they release new versions very rarely). And this rule can be quite invasive.

### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->
Before turning off the rule, an error would be reported for code like this because there was no `onBlur` handler. Now it should not be reported.

```javascript

<select onChange={() => {}} />

```

### Note
I also changed the test file/script a little bit to also include example of code that is supposed to be linted correctly. This will ensure that no broken rule configuration is merged. I might also add this test as a GitHub action in a separate PR so that it is executed automatically.

---

Paging @vazco/developers 