### PR TITLE
Introduce sort-keys rule

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -77,6 +77,12 @@ rules:
   object-shorthand: 2
   prefer-const: 2
   prefer-spread: 1
+  sort-keys:
+    - error
+    - asc
+    - caseSensitive: true
+      natural: false
+      minKeys: 2
   prettier/prettier:
     - error
     - arrowParens: avoid

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -82,7 +82,7 @@ rules:
     - asc
     - caseSensitive: true
       natural: false
-      minKeys: 2
+      minKeys: 3
   prettier/prettier:
     - error
     - arrowParens: avoid


### PR DESCRIPTION
<!-- READ THE INSTRUCTIONS AND FILL THE PULL REQUEST -->
<!-- 1) THESE COMMENTS WON'T BE ADDED TO THE PULL REQUEST -->
<!-- 2) DO NOT ADD ANY REVIEWERS - THERE IS A CODE AT THE BOTTOM THAT WILL CALL PEOPLE -->
<!-- 3) BEFORE SUBMITTING CHANGE TO PREVIEW TAB AND MAKE SURE EVERYTHING LOOKS OK! -->


Summary | <!-- Please fill values below: -->
:-----: | :-----:
Rule name: | sort-keys
Kind: | Add
Fixable? | No
Link to docs: | http://eslint.org/docs/rules/sort-keys

### Why?
<!-- Please write some short explanation -->
I want it, because declaring multiple properties devs prefer to sort property names alphabetically to find necessary properties quicker. This rule will enforce developers to run "Sort alphabetically" action in VScode/WebStorm if the number of props is more than 3.

### Examples of BAD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

const obj = { c: 3, a: 1, b: 2 };

```

### Examples of GOOD code for this rule:
<!-- Could be copied from ESLint docs, or write your own -->

```javascript

const obj = { C: 3, a: 1, b: 2 };
const obj = { a: 1, b: 2, c: 3 };

```


<!-- Leave this as it is, this will call everyone interested in this PR -->
---
Requesting feedback from: @vazco/developers
